### PR TITLE
⬆️ ci(actions): upgrade actions/cache to v5.0.4

### DIFF
--- a/.github/actions/setup-rust-cache/action.yml
+++ b/.github/actions/setup-rust-cache/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Restore cargo home
       id: cargo_restore
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cargo/bin
@@ -57,7 +57,7 @@ runs:
     - name: Restore sccache (fallback)
       id: sccache_restore
       if: ${{ env.SCCACHE_GHA_ENABLED != 'true' }}
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-${{ inputs.cache-scope }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
@@ -68,7 +68,7 @@ runs:
     - name: Save cargo home
       if: ${{ always() && !cancelled() && steps.cargo_restore.outputs.cache-hit != 'true' }}
       continue-on-error: true
-      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cargo/bin
@@ -80,7 +80,7 @@ runs:
     - name: Save sccache (fallback)
       if: ${{ always() && !cancelled() && env.SCCACHE_GHA_ENABLED != 'true' && steps.sccache_restore.outputs.cache-hit != 'true' }}
       continue-on-error: true
-      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-${{ inputs.cache-scope }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: 1.97.1
 
       - name: Cache cargo-audit and the advisory database
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cargo/bin/cargo-audit


### PR DESCRIPTION
Upgrades actions/cache (including the restore/save sub-actions) from v4.2.3 to v5.0.4, removing the Node.js 20 deprecation warning. Same cache API, same SHA-pinned supply-chain boundary.