### PR TITLE
🐛 fix(ci): repair postmerge CI and pin current actions

### DIFF
--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -22,6 +22,6 @@ runs:
         echo "TMP=${ci_root}/tmp" >> "$GITHUB_ENV"
 
     - name: Install just
-      uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+      uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
       with:
         tool: just@1.58.0

--- a/.github/actions/setup-linux-deps/action.yml
+++ b/.github/actions/setup-linux-deps/action.yml
@@ -4,19 +4,28 @@ description: Install the pinned Linux build dependencies with a resilient apt mi
 runs:
   using: composite
   steps:
-    - name: Pin apt to the global Ubuntu archive
+    - name: Pin apt to the architecture's Ubuntu archive
       shell: bash
       run: |
         set -euo pipefail
         # 🧭 GitHub-hosted runners resolve azure.archive.ubuntu.com through a
         # mirrorlist, and that mirror has repeatedly hung or crawled for
-        # minutes. Pin every source directly to the global archive.ubuntu.com
-        # CDN, and rewrite the mirrorlist too in case something re-reads it.
+        # minutes. Pin every source directly to a stable CDN, choosing the
+        # archive that actually carries the runner's architecture:
+        # archive.ubuntu.com serves amd64, while every other Ubuntu port
+        # (arm64 among them) lives on ports.ubuntu.com.
+        arch="$(dpkg --print-architecture 2>/dev/null || uname -m)"
+        if [[ "${arch}" == "amd64" ]]; then
+          ubuntu_url="http://archive.ubuntu.com/ubuntu/"
+        else
+          ubuntu_url="http://ports.ubuntu.com/ubuntu-ports/"
+        fi
+        echo "Using ${ubuntu_url} for ${arch}"
         if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
-          sudo sed -i 's|^URIs:.*|URIs: http://archive.ubuntu.com/ubuntu/|' /etc/apt/sources.list.d/ubuntu.sources
+          sudo sed -i "s|^URIs:.*|URIs: ${ubuntu_url}|" /etc/apt/sources.list.d/ubuntu.sources
         fi
         if [[ -f /etc/apt/apt-mirrors.txt ]]; then
-          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
+          sudo sed -i -E "s|https?://azure\.archive\.ubuntu\.com/ubuntu/?|${ubuntu_url}|g" /etc/apt/apt-mirrors.txt
         fi
 
     - name: Update apt with a hard deadline and IPv4
@@ -42,4 +51,4 @@ runs:
           -o Acquire::Retries=3 \
           -o Acquire::http::Timeout=60 \
           -o Acquire::https::Timeout=60 \
-          cmake make g++ perl pkg-config clang libclang-dev git curl ca-certificates
+          cmake make g++ perl pkg-config clang libclang-dev git curl ca-certificates xz-utils

--- a/.github/actions/setup-rust-cache/action.yml
+++ b/.github/actions/setup-rust-cache/action.yml
@@ -38,7 +38,7 @@ runs:
           cargo-home-${{ inputs.cache-scope }}-${{ inputs.target }}-${{ inputs.profile }}-
 
     - name: Install sccache
-      uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+      uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
       with:
         tool: sccache@0.17.0
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,7 +42,7 @@ workflow, so a red result never masks another.
 2. Prefer a reusable workflow (`on: workflow_call`) and call it from
    `blocking-ci.yml` or `postmerge-ci.yml`.
 3. Pin every third-party action to a commit SHA with a human-readable version
-   comment (for example `# v5.1.0`); every checkout uses
+   comment (for example `# v7.0.1`); every checkout uses
    `persist-credentials: false`.
 4. Any job that can generate files ends with `check-clean-worktree`, so
    formatting, codegen, or lockfile updates cannot silently stay uncommitted.

--- a/.github/workflows/blob-size-policy.yml
+++ b/.github/workflows/blob-size-policy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/blocking-ci.yml
+++ b/.github/workflows/blocking-ci.yml
@@ -75,7 +75,7 @@ jobs:
       - blob-size-policy
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Require successful dependencies

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -21,7 +21,7 @@ jobs:
           toolchain: 1.97.1
 
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           rust-version: 1.97.1
           manifest-path: ./Cargo.toml

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check whitespace (git log --check)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -33,7 +33,7 @@ jobs:
     name: Check commit subjects (emoji + conventional)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -62,7 +62,7 @@ jobs:
     name: Workspace version is ahead of the newest release tag
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,7 +34,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             key: aarch64
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
@@ -75,7 +75,7 @@ jobs:
           shasum -a 256 pingclair-linux-${{ matrix.platform.key }}-dev.tar.gz > SHA256SUMS-dev-${{ matrix.platform.key }}.txt
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pingclair-linux-${{ matrix.platform.key }}-dev
           path: |
@@ -91,12 +91,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Download dev binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
 
@@ -160,23 +160,23 @@ jobs:
             platform: linux/arm64
             tag: arm64
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the ${{ matrix.platform.name }} image
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: deployment/Dockerfile
@@ -208,16 +208,16 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/h3.yml
+++ b/.github/workflows/h3.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -34,10 +34,16 @@ jobs:
       - name: Install HTTP/3-capable curl
         run: |
           set -euo pipefail
-          curl -fsSL --retry 3 -o /tmp/curl-amd64 \
-            https://github.com/moparisthebest/static-curl/releases/download/v8.21.0/curl-amd64
-          echo "e45ae1805ceb3f816e9768fbbaba05d98a2dc9c5577f66395f37660941d88e19  /tmp/curl-amd64" | sha256sum -c -
-          sudo install -m 0755 /tmp/curl-amd64 /usr/local/bin/curl
+          # 🛰️ moparisthebest/static-curl only ships curl-amd64, and its
+          # v8.21.0 build has no ngtcp2/nghttp3. stunnel/static-curl compiles
+          # curl with HTTP/3 and publishes per-architecture tarballs with
+          # SHA256SUMS, so pin both the tarball and the extracted binary.
+          curl -fsSL --retry 3 -o /tmp/curl-linux-x86_64-glibc-8.21.0.tar.xz \
+            https://github.com/stunnel/static-curl/releases/download/8.21.0/curl-linux-x86_64-glibc-8.21.0.tar.xz
+          echo "0ebe99e278b9083db5730d557d7fbd354167aa3182b4724df75631f9bc15ba48  /tmp/curl-linux-x86_64-glibc-8.21.0.tar.xz" | sha256sum -c -
+          tar -xJf /tmp/curl-linux-x86_64-glibc-8.21.0.tar.xz -C /tmp
+          echo "53368902f64d4d1a4c4d12e31b82caba118d11e393e68a98ecf2723e212a735b  /tmp/curl" | sha256sum -c -
+          sudo install -m 0755 /tmp/curl /usr/local/bin/curl
           /usr/local/bin/curl --version | grep -qi 'http3'
 
       - name: Run the HTTP/3 functional matrix

--- a/.github/workflows/postmerge-ci.yml
+++ b/.github/workflows/postmerge-ci.yml
@@ -28,7 +28,7 @@ jobs:
     needs: [rust-ci-full, h3]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Require successful dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       version: ${{ steps.info.outputs.version }}
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -67,7 +67,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             key: aarch64
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -107,7 +107,7 @@ jobs:
           shasum -a 256 pingclair-linux-${{ matrix.platform.key }}.tar.gz > SHA256SUMS-${{ matrix.platform.key }}.txt
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pingclair-linux-${{ matrix.platform.key }}
           path: |
@@ -123,13 +123,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Download release binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
 
@@ -178,22 +178,22 @@ jobs:
             platform: linux/arm64
             tag: arm64
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the ${{ matrix.platform.name }} image
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: deployment/Dockerfile
@@ -220,15 +220,15 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       NEXTEST_ARCHIVE_FILE: nextest-${{ inputs.artifact_id }}.tar.zst
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -48,7 +48,7 @@ jobs:
           cache-scope: nextest-${{ inputs.artifact_id }}
 
       - name: Install nextest
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: nextest@0.9.143
 
@@ -68,14 +68,14 @@ jobs:
 
       - name: Upload Cargo timings
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cargo-timings-nextest-${{ inputs.artifact_id }}
           path: ${{ env.CARGO_TARGET_DIR }}/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
       - name: Upload nextest archive
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextest-archive-${{ inputs.artifact_id }}
           path: ${{ runner.temp }}/${{ env.NEXTEST_ARCHIVE_FILE }}
@@ -83,7 +83,7 @@ jobs:
           retention-days: 1
 
       - name: Upload the real binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pingclair-bin-${{ inputs.artifact_id }}
           path: ${{ env.CARGO_TARGET_DIR }}/${{ inputs.target }}/${{ inputs.profile }}/pingclair
@@ -102,7 +102,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -114,18 +114,18 @@ jobs:
           toolchain: 1.97.1
 
       - name: Install nextest
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: nextest@0.9.143
 
       - name: Download nextest archive
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nextest-archive-${{ inputs.artifact_id }}
           path: ${{ runner.temp }}/nextest-archive
 
       - name: Download the real binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pingclair-bin-${{ inputs.artifact_id }}
           path: ${{ runner.temp }}/pingclair-bin
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload nextest JUnit report
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextest-junit-${{ inputs.artifact_id }}-shard-${{ matrix.shard }}
           path: ${{ env.CARGO_TARGET_DIR }}/nextest/ci/junit.xml

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -73,7 +73,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Require successful dependencies

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -17,7 +17,7 @@ jobs:
       docs: ${{ steps.detect.outputs.docs }}
       docker: ${{ steps.detect.outputs.docker }}
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -62,7 +62,7 @@ jobs:
     if: ${{ needs.changed.outputs.rust == 'true' || needs.changed.outputs.workflows == 'true' }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -83,12 +83,12 @@ jobs:
           cache-scope: rust-ci
 
       - name: Install nextest
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: nextest@0.9.143
 
       - name: Install cargo-shear
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-shear@1.13.4
 
@@ -99,7 +99,7 @@ jobs:
           echo "/tmp/codespell-venv/bin" >> "$GITHUB_PATH"
 
       - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Fixes the two failing postmerge jobs on `main` and modernizes the remaining third-party action pins.

## What changed

**Postmerge CI fixes**
- `h3.yml`: replace `moparisthebest/static-curl` (amd64-only, no ngtcp2/nghttp3) with `stunnel/static-curl` 8.21.0, which builds curl with HTTP/3. Both the tarball and the extracted binary are SHA-256 pinned, and the extracted binary was verified to advertise HTTP3.
- `setup-linux-deps`: pick the apt mirror by architecture — `archive.ubuntu.com` for amd64, `ports.ubuntu.com/ubuntu-ports` for arm64 and other ports — instead of pinning every runner to the amd64-only archive. Also adds `xz-utils` so the H3 job can unpack the curl tarball.

**Action upgrades** (all inputs verified backward compatible with current usage)
- `actions/checkout` v5.1.0 → v7.0.1
- `actions/upload-artifact` v4.6.2 → v7.0.1
- `actions/download-artifact` v4.3.0 → v8.0.1
- `actions/setup-node` v6.3.0 → v7.0.0
- `docker/setup-buildx-action` v3.10.0 → v4.2.0
- `docker/login-action` v3.4.0 → v4.6.0
- `docker/build-push-action` v6.15.0 → v7.3.0
- `taiki-e/install-action` v2.62.49 → v2.86.3
- `EmbarkStudios/cargo-deny-action` comment updated to the already-pinned v2.1.1 SHA

## Notes

- This PR is based on `main` and intentionally does not include the `actions/cache` v5 upgrade from #4; the two PRs touch different lines and can merge in either order.
- `actions/cache` stays at v4.2.3 here; v6 has breaking changes to evaluate separately.

## Verification

- `actionlint`, `just repo-lint`, and `just docs-lint` pass locally.
- Blocking CI on this PR covers the amd64 apt path and all upgraded actions.
- The H3 suite and the aarch64 nextest archive are postmerge-only, so I will dispatch `h3.yml` and `rust-ci-full.yml` against this branch before merge.