### PR TITLE
🧪 fix(ci): harden flaky-test retry handling and timing

### DIFF
--- a/pingclair/tests/integration.rs
+++ b/pingclair/tests/integration.rs
@@ -1451,7 +1451,10 @@ async fn test_bounded_upstream_status_retry_preserves_request_body_safety() {
         .unwrap();
     assert_eq!(response.status(), 504);
     assert!(started.elapsed() >= Duration::from_millis(70));
-    assert!(started.elapsed() < Duration::from_millis(250));
+    // 💤 The hit counter below is the definitive no-retry proof: a loaded
+    // runner can stretch one 100 ms budget past 250 ms, but it cannot make
+    // the upstream accept the same request twice.
+    assert!(started.elapsed() < Duration::from_millis(1_500));
     assert_eq!(slow_deadline_hits.load(Ordering::SeqCst), 1);
 
     // ⌛ The terminal retry timeout also closes its downstream connection.

--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -47,7 +47,11 @@ fi
 
 extract_failures() {
   local log="$1"
-  rg '^FAIL \[[^]]+\] (\S+)' -or '$1' "$log" | sort -u
+  # 🎨 Strip ANSI colour codes first: CI forces coloured nextest output, so a
+  # plain `^FAIL` match would see an escape sequence, not the letter F. Perl is
+  # present on every runner and the developer's macOS, so it is safer than
+  # depending on ripgrep being installed on the runner.
+  perl -ne 's/\e\[[0-9;]*m//g; if (/^\s*FAIL \[[^\]]+\]/) { my @fields = split; print "$fields[-1]\n" }' "$log" | sort -u
   awk '/^Failure list:/{f=1; next} f && /^[[:space:]]*[0-9]+\./{print $2}' "$log" | sort -u
 }
 
@@ -90,7 +94,7 @@ while [ "$attempt" -lt "$max_attempts" ]; do
   fi
 done
 
-rg -E 'Summary|test result|passed|failed' "$log" | tail -20 || true
+grep -E 'Summary|test result|passed|failed' "$log" | tail -20 || true
 if [ "$status" -ne 0 ]; then
   echo "::error::nextest failed on: $(printf '%s' "$failed" | tr '\n' ' ')"
   tail -n 80 "$log"


### PR DESCRIPTION
Two test-robustness fixes for the CI flaky-test path.

## 1. Make the known-flaky retry actually work

The websocket tunnel flake is already admitted to the retry allowlist, but the retry parser never got a chance to see it: `scripts/run-ci-tests.sh` depends on `rg`, which is not installed on the runner, and its `^FAIL` anchor would miss the ANSI colour codes CI forces into nextest output even if ripgrep existed.

The parser now strips colour codes and extracts failure names with `perl` (present on every runner and on the developer's macOS), and the summary grep falls back to `grep`.

## 2. Loosen the slow-deadline retry timing bound

The `/slow-deadline` case asserts the whole request completes under 250 ms, but a loaded CI runner can stretch the single 100 ms budget past that on scheduling delay alone. The `slow_deadline_hits == 1` counter immediately after is the definitive no-retry proof, so the redundant ceiling is widened to the same 1.5 s bound the `/deadline` branch already uses.

Test-only and CI-script changes; no runtime code is touched.