### PR TITLE
🐛 fix(ci): expand CARGO_TARGET_DIR in artifact upload paths

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -79,8 +79,8 @@ jobs:
         with:
           name: pingclair-linux-${{ matrix.platform.key }}-dev
           path: |
-            ${CARGO_TARGET_DIR}/${{ matrix.platform.target }}/release/pingclair-linux-${{ matrix.platform.key }}-dev.tar.gz
-            ${CARGO_TARGET_DIR}/${{ matrix.platform.target }}/release/SHA256SUMS-dev-${{ matrix.platform.key }}.txt
+            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.platform.target }}/release/pingclair-linux-${{ matrix.platform.key }}-dev.tar.gz
+            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.platform.target }}/release/SHA256SUMS-dev-${{ matrix.platform.key }}.txt
           retention-days: 14
 
   publish-dev-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,8 @@ jobs:
         with:
           name: pingclair-linux-${{ matrix.platform.key }}
           path: |
-            ${CARGO_TARGET_DIR}/${{ matrix.platform.target }}/release/pingclair-linux-${{ matrix.platform.key }}.tar.gz
-            ${CARGO_TARGET_DIR}/${{ matrix.platform.target }}/release/SHA256SUMS-${{ matrix.platform.key }}.txt
+            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.platform.target }}/release/pingclair-linux-${{ matrix.platform.key }}.tar.gz
+            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.platform.target }}/release/SHA256SUMS-${{ matrix.platform.key }}.txt
           retention-days: 7
 
   publish-release:


### PR DESCRIPTION
Dev builds broke after the upload-artifact v7 upgrade: v7 no longer expands shell-style `${VAR}` inside the `path` input, so the dev upload found zero files, the download found zero artifacts, and checksum verification failed.

This switches the `path` entries in `dev.yml` and `release.yml` to the GitHub expression form `${{ env.CARGO_TARGET_DIR }}`, which the action actually evaluates. The release upload has the same latent bug and is fixed in the same change.