### PR TITLE
🛡️ fix(deps): remove vulnerable protobuf and OpenTelemetry paths

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Audit dependencies
         run: cargo audit
 
-      - name: Audit the crates hidden behind [patch.crates-io]
+      - name: Audit the registry h2 hidden behind [patch.crates-io]
         run: |
           set -Eeuo pipefail
-          python3 -c 'import io,sys; p="Cargo.toml"; m=open(p).read(); s=m.index("[patch.crates-io]"); e=m.index("[profile.release]"); open(p,"w").write(m[:s]+m[e:])'
-          if grep -q '^\[patch.crates-io\]' Cargo.toml; then
-              echo "::error::failed to strip the patch section; the audit below would be a no-op" >&2
+          python3 -c 'p="Cargo.toml"; m=open(p).read(); m=m.replace("h2 = { path = \"vendor/h2\" }\n", ""); open(p,"w").write(m)'
+          if grep -q '^h2 = { path = "vendor/h2" }' Cargo.toml; then
+              echo "::error::failed to remove the h2 patch; the audit below would miss the registry crate" >&2
               exit 1
           fi
           cargo generate-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -105,11 +105,13 @@ __pycache__/
 # session but not part of the shipped repository.
 docs/CADDYFILE*.md
 
-# ⚡ Vendored crates: the h2 performance fork ships with the repository
-# (see vendor/h2/PINGCLAIR_PATCH.md); anything else under vendor/ is local
-# scratch space.
+# ⚡ Vendored crates: the h2 performance fork and the two security compatibility
+# crates ship with the repository; anything else under vendor/ is local scratch
+# space.
 vendor/*
+!vendor/foundations-compat/
 !vendor/h2/
+!vendor/prometheus-compat/
 vendor/h2/Cargo.lock
 
 # 🔬 Verification-day working material: the scripts a Day runs against a clean

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,18 +707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
-name = "const-hex"
-version = "1.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,7 +1154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1258,48 +1246,46 @@ dependencies = [
 
 [[package]]
 name = "foundations"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f830dc97d74f1cb072be57e1099db679a5c935d2be640fe730fcda98eb3559e"
+version = "5.9.1"
+source = "git+https://github.com/cloudflare/foundations?rev=11f10eb9b0c4f9b3b5e9744d998ffe2bcfd6aa6c#11f10eb9b0c4f9b3b5e9744d998ffe2bcfd6aa6c"
 dependencies = [
  "anyhow",
- "cf-rustracing",
- "cf-rustracing-jaeger",
  "crossbeam-utils",
  "erased-serde 0.4.10",
  "foundations-macros",
  "futures-util",
  "governor",
- "http",
  "indexmap 2.14.0",
- "libc",
- "opentelemetry-proto",
  "parking_lot",
  "pin-project-lite",
  "prometheus 0.14.0",
  "prometheus-client",
  "prometools",
- "rand 0.10.2",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "serde_with",
  "serde_yaml 0.8.26",
- "slab",
  "slog",
  "slog-async",
  "slog-json",
  "slog-term",
  "thread_local",
- "tokio",
  "yaml-merge-keys",
+ "zeroize",
+]
+
+[[package]]
+name = "foundations"
+version = "5.9.2"
+dependencies = [
+ "foundations 5.9.1",
 ]
 
 [[package]]
 name = "foundations-macros"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8851c1de933e2320aa59793a04a0b79273ad93d2c6b29169389df05a68745797"
+version = "5.9.1"
+source = "git+https://github.com/cloudflare/foundations?rev=11f10eb9b0c4f9b3b5e9744d998ffe2bcfd6aa6c#11f10eb9b0c4f9b3b5e9744d998ffe2bcfd6aa6c"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1766,19 +1752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,7 +2016,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2547,52 +2520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.19",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
-dependencies = [
- "base64",
- "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry",
- "percent-encoding",
- "rand 0.9.5",
- "thiserror 2.0.19",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,7 +2916,7 @@ dependencies = [
  "pingora-pool",
  "pingora-runtime",
  "pingora-timeout",
- "prometheus 0.13.4",
+ "prometheus 0.13.5",
  "rand 0.8.7",
  "regex",
  "serde",
@@ -3225,17 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+version = "0.13.5"
 dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf 2.28.0",
- "thiserror 1.0.69",
+ "prometheus 0.14.0",
 ]
 
 [[package]]
@@ -3251,7 +3170,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "procfs",
- "protobuf 3.7.2",
+ "protobuf",
  "thiserror 2.0.19",
 ]
 
@@ -3311,35 +3230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
 name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,7 +3255,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c65c0ae39cba4538fd935d376ba17f858046b386dc4597e3fa5c1aedb919ef30"
 dependencies = [
- "foundations",
+ "foundations 5.9.2",
  "humantime",
  "serde",
  "serde_json",
@@ -3472,7 +3362,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3825,7 +3715,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3838,7 +3728,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3906,7 +3796,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4486,7 +4376,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4681,7 +4571,7 @@ dependencies = [
  "bytes",
  "crossbeam",
  "datagram-socket",
- "foundations",
+ "foundations 5.9.2",
  "futures",
  "futures-util",
  "ipnetwork",
@@ -4794,43 +4684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
-name = "tonic"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4838,15 +4691,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5224,7 +5073,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ members = [
     "pingclair-api",
     "pingclair-plugin",
 ]
-exclude = ["vendor/h2"]
+exclude = [
+    "vendor/foundations-compat",
+    "vendor/h2",
+    "vendor/prometheus-compat",
+]
 
 [workspace.package]
 version = "0.2.0-dev"
@@ -197,7 +201,15 @@ arc-swap = "1"
 # in. Vendoring also removes `source`/`checksum` from the lockfile entry,
 # which makes the crate invisible to `cargo audit` — verified directly.
 [patch.crates-io]
+# 🛡️ These compatibility crates remove GHSA-2gh3-rmm4-6rq5 and
+# GHSA-w9wp-h8wv-79jx without carrying full forks. Pingora 0.8.1 still requests
+# Prometheus 0.13 even though upstream fixed its protobuf advisory by moving to
+# 0.14, and tokio-quiche 0.19.1 requests Foundations tracing even though it only
+# consumes the settings, logging, metrics, and testing APIs. Remove each shim
+# when the next upstream release exposes the safe dependency graph directly.
+foundations = { path = "vendor/foundations-compat" }
 h2 = { path = "vendor/h2" }
+prometheus = { path = "vendor/prometheus-compat" }
 
 [profile.release]
 lto = "fat"

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,6 @@ yanked = "deny"
 ignore = [
     { id = "RUSTSEC-2024-0320", reason = "yaml-rust is unmaintained; pulled in via foundations -> serde_yaml under quiche/tokio-quiche; no upstream fix yet" },
     { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained; pulled in via pingora-core; no upstream fix yet" },
-    { id = "RUSTSEC-2024-0437", reason = "protobuf 2.28.0 remains via prometheus -> pingora-core; it encodes our own metrics and never parses untrusted input; remove when pingora drops protobuf 2" },
     { id = "RUSTSEC-2025-0069", reason = "daemonize is unmaintained; pulled in via pingora-core daemon mode; no upstream fix yet" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is unmaintained; direct in pingclair-tls but only wraps rustls-pki-types; migrate to PemObject in a follow-up" },
     { id = "RUSTSEC-2026-0253", reason = "lru 0.16.4 is pulled in via pingora-cache and pingora-pool 0.8.1; the advisory concerns LruCache::pop() panic safety and Pingclair never calls lru directly; remove when pingora moves past lru 0.16" },

--- a/vendor/foundations-compat/Cargo.toml
+++ b/vendor/foundations-compat/Cargo.toml
@@ -2,6 +2,7 @@
 name = "foundations"
 version = "5.9.2"
 edition = "2024"
+license = "Apache-2.0"
 publish = false
 
 [features]

--- a/vendor/foundations-compat/Cargo.toml
+++ b/vendor/foundations-compat/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "foundations"
+version = "5.9.2"
+edition = "2024"
+publish = false
+
+[features]
+default = []
+logging = ["foundations-upstream/logging"]
+metrics = ["foundations-upstream/metrics"]
+server-client-common-default = ["logging", "metrics", "settings", "testing"]
+settings = ["foundations-upstream/settings"]
+testing = ["foundations-upstream/testing"]
+
+[dependencies]
+foundations-upstream = { package = "foundations", git = "https://github.com/cloudflare/foundations", rev = "11f10eb9b0c4f9b3b5e9744d998ffe2bcfd6aa6c", default-features = false }

--- a/vendor/foundations-compat/src/lib.rs
+++ b/vendor/foundations-compat/src/lib.rs
@@ -1,0 +1,1 @@
+pub use foundations_upstream::*;

--- a/vendor/prometheus-compat/Cargo.toml
+++ b/vendor/prometheus-compat/Cargo.toml
@@ -2,6 +2,7 @@
 name = "prometheus"
 version = "0.13.5"
 edition = "2024"
+license = "Apache-2.0"
 publish = false
 
 [dependencies]

--- a/vendor/prometheus-compat/Cargo.toml
+++ b/vendor/prometheus-compat/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "prometheus"
+version = "0.13.5"
+edition = "2024"
+publish = false
+
+[dependencies]
+prometheus-upstream = { package = "prometheus", version = "0.14" }

--- a/vendor/prometheus-compat/src/lib.rs
+++ b/vendor/prometheus-compat/src/lib.rs
@@ -1,0 +1,1 @@
+pub use prometheus_upstream::*;


### PR DESCRIPTION
## 📝 What this changes

Removes the two vulnerable runtime dependency paths reported by Dependabot: the protobuf uncontrolled-recursion crash and the OpenTelemetry W3C Baggage unbounded-allocation issue. Thin compatibility crates keep the APIs Pingora and tokio-quiche consume while resolving Prometheus through 0.14 and omitting the unused Foundations tracing feature.

Dependabot alerts: [protobuf #1](https://github.com/dorianverlaine/pingclair/security/dependabot/1), [opentelemetry_sdk #2](https://github.com/dorianverlaine/pingclair/security/dependabot/2).

## 🤔 Why

Pingora 0.8.1 still requests Prometheus 0.13, so Cargo retains protobuf 2.28.0 even though Pingclair already uses Prometheus 0.14 elsewhere. tokio-quiche 0.19.1 requests Foundations server-client-common-default, which activates distributed tracing and opentelemetry_sdk even though tokio-quiche only consumes settings, logging, metrics, and testing APIs.

A plain cargo update cannot cross either semver boundary. The compatibility crates remove the vulnerable code without carrying full upstream forks, and the security-audit workflow now removes only the h2 patch during its registry audit so it cannot accidentally resurrect both vulnerable paths.

## 🔬 Evidence

No application-level red-first test was added because both defects live in transitive packages. The strongest focused substitute is proving that neither vulnerable package can be resolved from Cargo.lock and then running RustSec against the resulting graph.

    cargo +1.97.1 tree -i protobuf@2.28.0
    error: package ID specification protobuf@2.28.0 did not match any packages

    cargo +1.97.1 tree -i opentelemetry_sdk
    error: package ID specification opentelemetry_sdk did not match any packages

    cargo audit
    Scanning Cargo.lock for vulnerabilities (524 crate dependencies)
    warning: 1 allowed warning found

The remaining warning is the repository-approved lru advisory. The modified second audit stage also passed in an isolated repository copy with registry h2 selected.

    just test -p pingclair-proxy
    Summary: 440 tests run: 440 passed

    just ci
    Summary: 1386 tests run: 1386 passed (1 leaky), 0 skipped
    bench smoke: passed

    just h3
    Day 28 H3 functional matrix: 27/27 passed
    H3 SSE, cancellation, and trailer rejection: passed
    H3 client authentication: 12/12 passed

The BoringSSL invariant remains intact: boring-sys resolves once at 4.22.0 and openssl-sys is absent.

## 🔀 Both transports?

- [x] Verified on H1/H2 through the full integration suite and client-auth matrix.
- [x] Verified on H3 through focused nextest coverage and all three maintained H3 scripts.

## 📚 Documentation

Nothing, because this is an internal dependency and CI correction with no operator-facing configuration or behavior change.

## 🤖 Which AI helped?

Codex (GPT-5.6 Sol Medium) implemented and verified the change.

## 🧯 CI follow-up

The first cargo-deny run exposed two missing license expressions in the local compatibility crate manifests. Commit 2541508 declares Apache-2.0 on both packages and removes the obsolete protobuf advisory exception.

    cargo deny check
    advisories ok, bans ok, licenses ok, sources ok
